### PR TITLE
Added curl install for interaction with RESTful services

### DIFF
--- a/ubuntu/arm-cross/Dockerfile
+++ b/ubuntu/arm-cross/Dockerfile
@@ -1,3 +1,3 @@
 FROM ubuntu:xenial
 
-RUN apt-get update -qq && apt-get install -y build-essential git gcc-arm-none-eabi
+RUN apt-get update -qq && apt-get install -y build-essential git gcc-arm-none-eabi curl


### PR DESCRIPTION
Some of our automated builds were failing because of missing curl. This should fix that.