### PR TITLE
Maint/more depends for autoware

### DIFF
--- a/ros/kinetic/autoware-ci/Dockerfile
+++ b/ros/kinetic/autoware-ci/Dockerfile
@@ -39,40 +39,57 @@ RUN apt update -qq && apt install -y -q \
     python-rospkg \
     python-serial \
     python-yaml \
+    python3-colcon-common-extensions \
     python3-pip \
     python3-setuptools \
     qtbase5-dev \
+    ros-kinetic-automotive-navigation-msgs \
+    ros-kinetic-automotive-platform-msgs \
     ros-kinetic-camera-info-manager \
     ros-kinetic-catkin \
     ros-kinetic-cmake-modules \
     ros-kinetic-cv-bridge \
+    ros-kinetic-diagnostic-aggregator \
     ros-kinetic-diagnostic-msgs \
     ros-kinetic-diagnostic-updater \
     ros-kinetic-dynamic-reconfigure \
+    ros-kinetic-effort-controllers \
+    ros-kinetic-gazebo-ros-control \
     ros-kinetic-geometry-msgs \
+    ros-kinetic-gps-common \
     ros-kinetic-grid-map-msgs \
     ros-kinetic-grid-map-ros \
     ros-kinetic-grid-map-visualization \
     ros-kinetic-gscam \
     ros-kinetic-image-geometry \
     ros-kinetic-image-transport \
+    ros-kinetic-image-view2 \
+    ros-kinetic-imu-filter-madgwick \
+    ros-kinetic-imu-tools \
+    ros-kinetic-joint-state-controller \
     ros-kinetic-jsk-recognition-msgs \
     ros-kinetic-jsk-rviz-plugins \
     ros-kinetic-message-generation \
     ros-kinetic-message-runtime \
     ros-kinetic-nav-msgs \
+    ros-kinetic-nmea-msgs \
     ros-kinetic-nodelet \
     ros-kinetic-pacmod-msgs \
     ros-kinetic-pcl-conversions \
     ros-kinetic-pcl-ros \
+    ros-kinetic-position-controllers \
     ros-kinetic-python-qt-binding \
     ros-kinetic-robot-state-publisher \
+    ros-kinetic-rosbridge-server \
     ros-kinetic-roscpp \
     ros-kinetic-rosgraph-msgs \
     ros-kinetic-roslib \
+    ros-kinetic-roslint \
     ros-kinetic-rospy \
     ros-kinetic-rostest \
     ros-kinetic-rosunit \
+    ros-kinetic-rqt-gui \
+    ros-kinetic-rqt-plot \
     ros-kinetic-rviz \
     ros-kinetic-sensor-msgs \
     ros-kinetic-sound-play \
@@ -80,6 +97,8 @@ RUN apt update -qq && apt install -y -q \
     ros-kinetic-tf \
     ros-kinetic-tf2 \
     ros-kinetic-tf2-geometry-msgs \
+    ros-kinetic-transmission-interface \
+    ros-kinetic-velocity-controllers \
     ros-kinetic-velodyne \
     ros-kinetic-velodyne-description \
     ros-kinetic-velodyne-gazebo-plugins \

--- a/ros/kinetic/autoware-ci/Dockerfile
+++ b/ros/kinetic/autoware-ci/Dockerfile
@@ -1,85 +1,89 @@
 FROM autonomoustuff/docker-builds:kinetic-perception
 
-RUN apt-get update -qq && apt-get install -y -q \
-    libeigen3-dev \
-    freeglut3-dev \
-    qtbase5-dev \
-    libgflags-dev \
-    python-serial \
-    libpcl-dev \
-    libcurl4-openssl-dev \
+RUN apt update -qq && apt install -y -q \
     curl \
-    python-yaml \
-    libssh2-1 \
-    v4l-utils \
-    libpcap0.8-dev \
-    libgl1-mesa-dev \
-    libglu1-mesa-dev \
+    freeglut3-dev \
+    gksu \
     gstreamer0.10-plugins-good \
-    libgtest-dev \
-    python-flask \
-    libyaml-cpp-dev \
-    libqt5opengl5-dev \
-    libboost-all-dev \
-    libx11-dev \
-    libqt5core5a \
-    libqt5widgets5 \
-    python-rospkg \
-    libopencv-dev \
     libarmadillo-dev \
-    libtinyxml-dev \
-    libxi-dev \
-    libqt5opengl5 \
-    libxmu-dev \
-    libpcl1.7 \
+    libboost-all-dev \
+    libcurl4-openssl-dev \
+    libeigen3-dev \
+    libgflags-dev \
+    libgl1-mesa-dev \
     libglew-dev \
-    mercurial \
-    python-requests \
-    python-imaging \
-    libqt5gui5 \
+    libglu1-mesa-dev \
     libgoogle-glog-dev \
+    libgtest-dev \
+    libmosquitto-dev \
+    libopencv-dev \
+    libpcap0.8-dev \
+    libpcl-dev \
+    libpcl1.7 \
+    libqt5core5a \
+    libqt5gui5 \
+    libqt5opengl5 \
+    libqt5opengl5-dev \
+    libqt5widgets5 \
+    libssh2-1 \
+    libtinyxml-dev \
+    libx11-dev \
+    libxi-dev \
+    libxmu-dev \
+    libyaml-cpp-dev \
+    mercurial \
+    python-flask \
+    python-imaging \
     python-nose \
-    ros-kinetic-visualization-msgs \
-    ros-kinetic-image-geometry \
-    ros-kinetic-velodyne \
-    ros-kinetic-tf2-geometry-msgs \
-    ros-kinetic-roscpp \
-    ros-kinetic-grid-map-ros \
-    ros-kinetic-tf \
-    ros-kinetic-sensor-msgs \
-    ros-kinetic-std-msgs \
-    ros-kinetic-geometry-msgs \
+    python-requests \
+    python-rospkg \
+    python-serial \
+    python-yaml \
+    python3-pip \
+    python3-setuptools \
+    qtbase5-dev \
+    ros-kinetic-camera-info-manager \
     ros-kinetic-catkin \
-    ros-kinetic-rosunit \
-    ros-kinetic-nav-msgs \
-    ros-kinetic-message-generation \
-    ros-kinetic-xacro \
-    ros-kinetic-jsk-rviz-plugins \
-    ros-kinetic-pcl-conversions \
-    ros-kinetic-pcl-ros \
-    ros-kinetic-jsk-recognition-msgs \
-    ros-kinetic-roslib \
-    ros-kinetic-message-runtime \
-    ros-kinetic-image-transport \
-    ros-kinetic-rviz \
-    ros-kinetic-python-qt-binding \
-    ros-kinetic-dynamic-reconfigure \
-    ros-kinetic-velodyne-pointcloud \
-    ros-kinetic-rospy \
-    ros-kinetic-diagnostic-updater \
-    ros-kinetic-gscam \
+    ros-kinetic-cmake-modules \
     ros-kinetic-cv-bridge \
-    ros-kinetic-robot-state-publisher \
-    ros-kinetic-velodyne-gazebo-plugins \
-    ros-kinetic-rostest \
     ros-kinetic-diagnostic-msgs \
-    ros-kinetic-tf2 \
-    ros-kinetic-velodyne-description \
+    ros-kinetic-diagnostic-updater \
+    ros-kinetic-dynamic-reconfigure \
+    ros-kinetic-geometry-msgs \
+    ros-kinetic-grid-map-msgs \
+    ros-kinetic-grid-map-ros \
+    ros-kinetic-grid-map-visualization \
+    ros-kinetic-gscam \
+    ros-kinetic-image-geometry \
+    ros-kinetic-image-transport \
+    ros-kinetic-jsk-recognition-msgs \
+    ros-kinetic-jsk-rviz-plugins \
+    ros-kinetic-message-generation \
+    ros-kinetic-message-runtime \
+    ros-kinetic-nav-msgs \
     ros-kinetic-nodelet \
     ros-kinetic-pacmod-msgs \
-    ros-kinetic-grid-map-msgs \
+    ros-kinetic-pcl-conversions \
+    ros-kinetic-pcl-ros \
+    ros-kinetic-python-qt-binding \
+    ros-kinetic-robot-state-publisher \
+    ros-kinetic-roscpp \
     ros-kinetic-rosgraph-msgs \
-    ros-kinetic-camera-info-manager \
-    ros-kinetic-cmake-modules \
+    ros-kinetic-roslib \
+    ros-kinetic-rospy \
+    ros-kinetic-rostest \
+    ros-kinetic-rosunit \
+    ros-kinetic-rviz \
+    ros-kinetic-sensor-msgs \
     ros-kinetic-sound-play \
-    ros-kinetic-grid-map-visualization
+    ros-kinetic-std-msgs \
+    ros-kinetic-tf \
+    ros-kinetic-tf2 \
+    ros-kinetic-tf2-geometry-msgs \
+    ros-kinetic-velodyne \
+    ros-kinetic-velodyne-description \
+    ros-kinetic-velodyne-gazebo-plugins \
+    ros-kinetic-velodyne-pointcloud \
+    ros-kinetic-visualization-msgs \
+    ros-kinetic-xacro \
+    v4l-utils

--- a/ros/kinetic/autoware-ci/Dockerfile
+++ b/ros/kinetic/autoware-ci/Dockerfile
@@ -106,3 +106,5 @@ RUN apt update -qq && apt install -y -q \
     ros-kinetic-visualization-msgs \
     ros-kinetic-xacro \
     v4l-utils
+
+RUN pip3 install -U setuptools


### PR DESCRIPTION
I ran the CI job again and saw that it still had a good amount of dependencies to install. To combat this, I SSH'd into the CI job instance and got the apt history. A little `vim` trickery later and they are added to the Dockerfile. I also sorted all the dependencies alphabetically so we can more easily see what has been added in the future and check for duplicates (thanks, `:sort`).