### PR TITLE
Adding missing SSH dependencies to Dashing containers.

### DIFF
--- a/ros2/dashing/ros-base/Dockerfile
+++ b/ros2/dashing/ros-base/Dockerfile
@@ -6,6 +6,8 @@ RUN apt update -qq && apt install -y -q \
     apt-transport-https \
     python3-colcon-common-extensions \
     software-properties-common \
+    openssh-client \
+    gnupg2 \
     && rm -rf /var/lib/apt/lists/*
 
 # Update rosdep

--- a/ros2/dashing/ros-core/Dockerfile
+++ b/ros2/dashing/ros-core/Dockerfile
@@ -6,6 +6,8 @@ RUN apt update -qq && apt install -y -q \
     apt-transport-https \
     python3-colcon-common-extensions \
     software-properties-common \
+    openssh-client \
+    gnupg2 \
     && rm -rf /var/lib/apt/lists/*
 
 # Update rosdep


### PR DESCRIPTION
Resolves #7. Tested locally. Instead of `failure to fork`, `git` now properly asks for verification of the RSA key fingerprint and fails if the SSH key doesn't exist or is incorrect for the repository.