### PR TITLE
Add missing catkin-tools dependency to Noetic images

### DIFF
--- a/ros/noetic/perception/Dockerfile
+++ b/ros/noetic/perception/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update -qq && apt-get install -y -q \
     build-essential \
     cmake \
     apt-transport-https \
+    python3-osrf-pycommon \
     python3-catkin-tools \
     openssh-client \
     && rm -rf /var/lib/apt/lists/*

--- a/ros/noetic/robot/Dockerfile
+++ b/ros/noetic/robot/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update -qq && apt-get install -y -q \
     build-essential \
     cmake \
     apt-transport-https \
+    python3-osrf-pycommon \
     python3-catkin-tools \
     openssh-client \
     && rm -rf /var/lib/apt/lists/*

--- a/ros/noetic/ros-base/Dockerfile
+++ b/ros/noetic/ros-base/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update -qq && apt-get install -y -q \
     build-essential \
     cmake \
     apt-transport-https \
+    python3-osrf-pycommon \
     python3-catkin-tools \
     openssh-client \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Resolves #16 by adding the missing dependency. See issue for more details.