### PR TITLE
Add tzdata and keyboard-configuration

### DIFF
--- a/ubuntu/bionic-non-root/Dockerfile
+++ b/ubuntu/bionic-non-root/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 
-RUN apt-get update && apt-get install -y sudo
+RUN apt-get update && apt-get install -y sudo tzdata keyboard-configuration
 
 RUN adduser --disabled-password --gecos '' as-user
 RUN adduser as-user sudo

--- a/ubuntu/focal-non-root/Dockerfile
+++ b/ubuntu/focal-non-root/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-RUN apt-get update && apt-get install -y sudo
+RUN apt-get update && apt-get install -y sudo tzdata keyboard-configuration
 
 RUN adduser --disabled-password --gecos '' as-user
 RUN adduser as-user sudo

--- a/ubuntu/xenial-non-root/Dockerfile
+++ b/ubuntu/xenial-non-root/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-RUN apt-get update && apt-get install -y sudo
+RUN apt-get update && apt-get install -y sudo tzdata keyboard-configuration
 
 RUN adduser --disabled-password --gecos '' as-user
 RUN adduser as-user sudo


### PR DESCRIPTION
Resolves #12 by pre-installing packages that will prompt for user input during installation. This sometimes breaks CI when the dependency chain decides to install these packages and they hang waiting for user input.